### PR TITLE
JBOSGI-579 Windows issues with jbosgi-repository

### DIFF
--- a/api/src/main/java/org/jboss/osgi/repository/RepositoryContentHelper.java
+++ b/api/src/main/java/org/jboss/osgi/repository/RepositoryContentHelper.java
@@ -44,20 +44,23 @@ public class RepositoryContentHelper {
      * Get the digest for a given input stream and algorithm
      */
     public static String getDigest(InputStream input, String algorithm) throws IOException, NoSuchAlgorithmException {
-        MessageDigest md = MessageDigest.getInstance(algorithm);
+        try {
+            MessageDigest md = MessageDigest.getInstance(algorithm);
 
-        int nread = 0;
-        byte[] dataBytes = new byte[1024];
-        while ((nread = input.read(dataBytes)) != -1) {
-            md.update(dataBytes, 0, nread);
-        }
-        byte[] mdbytes = md.digest();
+            int nread = 0;
+            byte[] dataBytes = new byte[1024];
+            while ((nread = input.read(dataBytes)) != -1) {
+                md.update(dataBytes, 0, nread);
+            }
+            byte[] mdbytes = md.digest();
 
-        StringBuilder builder = new StringBuilder();
-        for (byte b : mdbytes) {
-            builder.append(String.format("%02x", b));
+            StringBuilder builder = new StringBuilder();
+            for (byte b : mdbytes) {
+                builder.append(String.format("%02x", b));
+            }
+            return builder.toString();
+        } finally {
+            input.close();
         }
-        return builder.toString();
     }
-
 }

--- a/core/src/main/java/org/jboss/osgi/repository/core/FileBasedRepositoryStorage.java
+++ b/core/src/main/java/org/jboss/osgi/repository/core/FileBasedRepositoryStorage.java
@@ -258,10 +258,13 @@ public class FileBasedRepositoryStorage extends MemoryRepositoryStorage {
     }
 
     private boolean deleteRecursive(File file) {
+        boolean result = true;
+
         if (file.isDirectory()) {
             for (File aux : file.listFiles())
-                return deleteRecursive(aux);
+                result &= deleteRecursive(aux);
         }
-        return file.delete();
+        result &= file.delete();
+        return result;
     }
 }

--- a/core/src/test/java/org/jboss/test/osgi/repository/FileBasedRepositoryStorageTestCase.java
+++ b/core/src/test/java/org/jboss/test/osgi/repository/FileBasedRepositoryStorageTestCase.java
@@ -55,6 +55,7 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.Asset;
 import org.jboss.shrinkwrap.api.exporter.ZipExporter;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -77,11 +78,16 @@ public class FileBasedRepositoryStorageTestCase extends AbstractRepositoryTest {
 
     @Before
     public void setUp() throws IOException {
-        storageDir = new File("./target/repository");
-        deleteRecursive(storageDir);
+        storageDir = new File("./target/repository/" + System.currentTimeMillis());
         repository = Mockito.mock(XRepository.class);
         Mockito.when(repository.getName()).thenReturn("MockedRepo");
         storage = new FileBasedRepositoryStorage(repository, storageDir);
+    }
+
+    @After
+    public void teardown() {
+        new File("./target/bundleA.jar").delete();
+        deleteRecursive(storageDir);
     }
 
     @Test
@@ -119,6 +125,7 @@ public class FileBasedRepositoryStorageTestCase extends AbstractRepositoryTest {
 
     @Test
     public void testAddResourceFromOSGiMetadata() throws Exception {
+        getBundleA().as(ZipExporter.class).exportTo(new File("./target/bundleA.jar"), true);
 
         XResourceBuilder builder = XResourceBuilderFactory.create();
         Manifest manifest = new Manifest(getBundleA().get(JarFile.MANIFEST_NAME).getAsset().openStream());
@@ -138,6 +145,8 @@ public class FileBasedRepositoryStorageTestCase extends AbstractRepositoryTest {
 
     @Test
     public void testFileStorageRestart() throws Exception {
+        // Write the bundle to the location referenced by repository-testA.xml
+        getBundleA().as(ZipExporter.class).exportTo(new File("./target/bundleA.jar"), true);
 
         // Add a resource from XML
         RepositoryReader reader = getRepositoryReader("xml/repository-testA.xml");
@@ -152,6 +161,8 @@ public class FileBasedRepositoryStorageTestCase extends AbstractRepositoryTest {
 
     @Test
     public void testBundleInfo() throws Exception {
+        // Write the bundle to the location referenced by repository-testA.xml
+        getBundleA().as(ZipExporter.class).exportTo(new File("./target/bundleA.jar"), true);
 
         // Add a resource from XML
         RepositoryReader reader = getRepositoryReader("xml/repository-testA.xml");
@@ -167,6 +178,8 @@ public class FileBasedRepositoryStorageTestCase extends AbstractRepositoryTest {
 
     @Test
     public void testCustomNamespace() throws Exception {
+        // Write the bundle to the location referenced by repository-testA.xml
+        getBundleA().as(ZipExporter.class).exportTo(new File("./target/bundleA.jar"), true);
 
         // Add a resource from XML
         RepositoryReader reader = getRepositoryReader("xml/repository-testA.xml");
@@ -190,6 +203,7 @@ public class FileBasedRepositoryStorageTestCase extends AbstractRepositoryTest {
     private void verifyResource(XResource resource) throws Exception {
         InputStream input = ((RepositoryContent)resource).getContent();
         Assert.assertNotNull("RepositoryContent not null", input);
+        input.close();
 
         XCapability ccap = (XCapability) resource.getCapabilities(ContentNamespace.CONTENT_NAMESPACE).get(0);
         Assert.assertEquals("application/vnd.osgi.bundle", ccap.getAttribute(ContentNamespace.CAPABILITY_MIME_ATTRIBUTE));

--- a/core/src/test/java/org/jboss/test/osgi/repository/PersistentRepositoryTestCase.java
+++ b/core/src/test/java/org/jboss/test/osgi/repository/PersistentRepositoryTestCase.java
@@ -110,7 +110,14 @@ public class PersistentRepositoryTestCase extends AbstractRepositoryTest {
         assertEquals("One capability", 1, caps.size());
         cap = (XCapability) caps.iterator().next();
         URL url = new URL((String) cap.getAttribute(ContentNamespace.CAPABILITY_URL_ATTRIBUTE));
-        Assert.assertTrue("Local path: " + url, url.getPath().startsWith(storageDir.getAbsolutePath()));
+
+        String absolutePath = storageDir.getAbsolutePath();
+        // Convert the absolute path so that it works on Windows too
+        absolutePath = absolutePath.replace('\\', '/');
+        if (!absolutePath.startsWith("/"))
+            absolutePath = "/" + absolutePath;
+
+        Assert.assertTrue("Local path: " + url, url.getPath().startsWith(absolutePath));
 
         RepositoryContent content = (RepositoryContent) resource;
         Manifest manifest = new JarInputStream(content.getContent()).getManifest();


### PR DESCRIPTION
jbosgi-repository doesn't function properly on Windows because of input streams that are not properly closed. This prevents File.delete() and File.renameTo() from functioning properly.
